### PR TITLE
Collapsing the side navigation menu on smaller screens

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ app.post('/landing', function(req, res) {
 
 app.post('/home', function(req, res) {
   res.json({
-    title: "Home Page test"
+    title: "Home Page"
   });
 });
 

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ app.post('/landing', function(req, res) {
 
 app.post('/home', function(req, res) {
   res.json({
-    title: "Home Page"
+    title: "Home Page test"
   });
 });
 

--- a/src/components/layouts/Dashboard/index.jsx
+++ b/src/components/layouts/Dashboard/index.jsx
@@ -173,7 +173,7 @@ var HomePage = React.createClass({
               </Nav>
             </ul> 
             <div className="navbar-default sidebar" style={ { 'marginLeft': '-20px' } } role="navigation">
-              <div className="sidebar-nav navbar-collapse">
+              <div className="sidebar-nav navbar-collapse collapse">
                 
                 <ul className="nav in" id="side-menu">
 


### PR DESCRIPTION
Collapsing the side navigation menu by default in smaller screens. Without this, navigation menu occupies most of the screen
